### PR TITLE
Install claude CLI via npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Both container versions are based on the official Claude Code reference implemen
 - **User**: Non-root `node` user with limited sudo
 - **Shell**: ZSH with Oh My Zsh
 - **Languages**: Node.js
-- **Claude Code**: Installed via devcontainer features
+- **Claude Code**: Installed via npm (`npm install -g @anthropic-ai/claude`)
 
 ## 📦 Available Versions
 

--- a/setup-devcontainer.sh
+++ b/setup-devcontainer.sh
@@ -84,8 +84,7 @@ create_devcontainer_structure() {
     }
   },
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+    "ghcr.io/devcontainers/features/node:1": {}
   },
   "postStartCommand": "/bin/bash .devcontainer/init-firewall.sh",
   "remoteUser": "node",
@@ -152,8 +151,8 @@ RUN ARCH=$(dpkg --print-architecture) && \
 USER node
 
 # Install global npm packages directory
-ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
-ENV PATH=$PATH:/usr/local/share/npm-global/bin
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
 
 # Install Oh My Zsh
 ARG ZSH_IN_DOCKER_VERSION=1.2.0
@@ -167,8 +166,8 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
 # Set the default shell to zsh
 ENV SHELL=/bin/zsh
 
-# Install Claude Code (will be done via devcontainer features)
-# This is handled by the devcontainer feature in devcontainer.json
+# Install Claude Code CLI via npm
+RUN mkdir -p /home/node/.npm-global && npm install -g @anthropic-ai/claude
 
 CMD ["/bin/zsh"]
 EOF

--- a/setup-hardened-devcontainer.sh
+++ b/setup-hardened-devcontainer.sh
@@ -317,8 +317,7 @@ create_devcontainer_structure() {
     }
   },
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+    "ghcr.io/devcontainers/features/node:1": {}
   },
   "postStartCommand": "/bin/bash .devcontainer/init-security.sh",
   "remoteUser": "node",
@@ -431,6 +430,9 @@ RUN export HOME=/home/$USERNAME && \
 
 # Switch to user
 USER $USERNAME
+
+# Install Claude Code CLI via npm
+RUN npm install -g @anthropic-ai/claude
 
 # Shell history hardening (keep aliases separate)
 RUN echo "export HISTSIZE=10000" >> ~/.zshrc && \


### PR DESCRIPTION
## Summary
- install Claude CLI globally via npm in devcontainer scripts
- remove Anthropics devcontainer feature
- document npm-based installation in README

## Testing
- `bash -n setup-devcontainer.sh`
- `bash -n setup-hardened-devcontainer.sh`


------
https://chatgpt.com/codex/tasks/task_e_689eb7246d748331a7a0f25eb79ba637